### PR TITLE
Fix to make MediusTool always output UTF-8

### DIFF
--- a/MediusTool/Program.cs
+++ b/MediusTool/Program.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using CommandLine;
 using Newtonsoft.Json.Converters;
 using Org.BouncyCastle.Math;
+using System.Text;
 
 namespace MediusTool
 {
@@ -28,6 +29,8 @@ namespace MediusTool
 
         static int Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.UTF8;
+
             // Load asymmetric keys
             if (File.Exists(ASYM_KEYS_PATH))
             {


### PR DESCRIPTION
Otherwise the output can be UCS-2 which is 16-bit codepoints (2 bytes per character) which is hard to search through with git etc.